### PR TITLE
Revert "Enable search on type"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
 	"npm.fetchOnlinePackageInfo": false,
 	"npm.autoDetect": "off",
 	"workbench.editor.languageDetection": false,
-	"workbench.localHistory.enabled": false
+	"workbench.localHistory.enabled": false,
+	"search.searchOnType": false
 }


### PR DESCRIPTION
Reverts microsoft/vscode-smoketest-express#13

This PR was originally merged because candidates were still getting merged using the old version of the smoke test, so the smoketest repo wasn't ready for these changes. These changes accompany https://github.com/microsoft/vscode/pull/161652